### PR TITLE
Better handling of skipped imports

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@ REPO_MAINTAINERS = [
 ]
 
 # Package version in the format (major, minor, release)
-PACKAGE_VERSION_TUPLE = (0, 2, 1)
+PACKAGE_VERSION_TUPLE = (0, 2, 2)
 
 # Short description of the package
 PACKAGE_SHORT_DESCRIPTION = "Generate Python configuration files from functions and classes and run them from the command line or Python"

--- a/pyfileconf/imports/logic/load/name.py
+++ b/pyfileconf/imports/logic/load/name.py
@@ -4,6 +4,8 @@ import sys
 
 from pyfileconf.exceptions.imports import CouldNotDetermineModuleForObjectException
 from pyfileconf.imports.logic.load.skipmodules import skip_modules
+from pyfileconf.sectionpath.sectionpath import SectionPath
+
 
 def get_imported_obj_variable_name(obj, module: ModuleType) -> str:
     key_list, value_list = _get_module_keys_and_values_lists(module)
@@ -17,7 +19,7 @@ def get_module_and_name_imported_from(obj, search_list: List[str]=None) -> Tuple
     for module_name in search_list:
 
         # skip modules which were causing issues
-        if module_name in skip_modules:
+        if _should_skip_module(module_name):
             continue
 
         module = sys.modules[module_name]
@@ -33,7 +35,7 @@ def is_imported_name(name: str, search_list: List[str]=None) -> bool:
     for module_name in search_list:
 
         # skip modules which were causing issues
-        if module_name in skip_modules:
+        if _should_skip_module(module_name):
             continue
 
         module = sys.modules[module_name]
@@ -49,7 +51,7 @@ def is_imported_obj(obj, search_list: List[str]=None) -> bool:
     for module_name in search_list:
 
         # skip modules which were causing issues
-        if module_name in skip_modules:
+        if _should_skip_module(module_name):
             continue
 
         module = sys.modules[module_name]
@@ -66,7 +68,7 @@ def _is_imported_from(name: str, search_list: List[str]=None) -> List[str]:
     for module_name in search_list:
 
         # skip modules which were causing issues
-        if module_name in skip_modules:
+        if _should_skip_module(module_name):
             continue
 
         module = sys.modules[module_name]
@@ -106,3 +108,15 @@ def _obj_in_module(obj, module: ModuleType) -> bool:
 
 def _name_in_module(name: str, module: ModuleType) -> bool:
     return name in dir(module)
+
+
+def _should_skip_module(name: str) -> bool:
+    """
+    Check if module section path ends with a section path in skip_models
+    """
+    module_section_path = SectionPath(name)
+    for skip_name in skip_modules:
+        skip_sp = SectionPath(skip_name)
+        if module_section_path.endswith(skip_sp):
+            return True
+    return False

--- a/pyfileconf/imports/logic/load/skipmodules.py
+++ b/pyfileconf/imports/logic/load/skipmodules.py
@@ -1,5 +1,5 @@
 
 # these modules are causing issues. Skip them when scanning for objects in modules
 skip_modules = [
-    'six.moves' # causes error ModuleNotFoundError: No module named '_gdbm'
+    'six.moves',  # causes error ModuleNotFoundError: No module named '_gdbm'
 ]

--- a/pyfileconf/io/func/load/args.py
+++ b/pyfileconf/io/func/load/args.py
@@ -51,6 +51,13 @@ def extract_function_args_and_arg_imports_from_import(function_name: str, imp: O
 
     loader = ImportAssignmentLazyLoader(filepath)
 
+    # TODO: handle relative nested imports such as from .this import that
+    #
+    # This code keeps importing and checking whether the name is defined in the file. If not,
+    # it follows the next import. This doesn't properly work if one of those followed imports
+    # is a relative import such as `from .this import that`. Add test to show this and
+    # also fix it.
+
     ast_function_def = extract_function_definition_or_class_init_from_ast_by_name(
         loader.ast,
         function_name

--- a/pyfileconf/sectionpath/sectionpath.py
+++ b/pyfileconf/sectionpath/sectionpath.py
@@ -45,6 +45,14 @@ class SectionPath(ReprMixin):
         relative_path = _section_path_to_relative_filepath(self)
         return os.path.join(basepath, relative_path)
 
+    def endswith(self, sp: 'SectionPath'):
+        num_to_match = len(sp)
+        match_parts = self[-num_to_match:]
+        for i, part in enumerate(match_parts):
+            if part != sp[i]:
+                return False
+        return True
+
 
 def _section_path_str_to_section_strs(section_path_str: str) -> List[str]:
     return section_path_str.split('.')

--- a/tests/input_files/amodule.py
+++ b/tests/input_files/amodule.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Tuple, Optional
 
-from tests.input_files.bmodule import ExampleClass
+from tests.input_files.mypackage.cmodule import ExampleClass
 
 
 def a_function(a: ExampleClass, b: List[str]) -> Tuple[ExampleClass, List[str]]:

--- a/tests/input_files/bmodule.py
+++ b/tests/input_files/bmodule.py
@@ -1,10 +1,3 @@
-from dataclasses import dataclass
-from typing import List, Tuple, Optional
 
 
-@dataclass
-class ExampleClass:
 
-    def __init__(self, a: Optional[Tuple[int, int]] = None, name: Optional[str] = None):
-        self.a = a
-        self.name = name

--- a/tests/input_files/mypackage/cmodule.py
+++ b/tests/input_files/mypackage/cmodule.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass
+class ExampleClass:
+
+    def __init__(self, a: Optional[Tuple[int, int]] = None, name: Optional[str] = None):
+        self.a = a
+        self.name = name

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -5,7 +5,7 @@ from typing import Sequence, Type, Union, Dict, List
 from pyfileconf import PipelineManager, Selector
 from pyfileconf.main import create_project
 from pyfileconf.sectionpath.sectionpath import SectionPath
-from tests.input_files.bmodule import ExampleClass
+from tests.input_files.mypackage.cmodule import ExampleClass
 from tests.utils import delete_project, pipeline_dict_str_with_obj, class_dict_str
 from tests.input_files.amodule import a_function, SecondExampleClass
 
@@ -117,7 +117,7 @@ class PipelineManagerTestBase:
 
     def write_example_class_to_pipeline_dict_file(self):
         with open(self.pipeline_dict_path, 'w') as f:
-            f.write(pipeline_dict_str_with_obj(ExampleClass, 'stuff', 'tests.input_files.bmodule'))
+            f.write(pipeline_dict_str_with_obj(ExampleClass, 'stuff', 'tests.input_files.mypackage.cmodule'))
 
     def write_example_class_dict_to_file(self, idx: int = 0):
         with open(self.example_class_dict_paths[idx], 'w') as f:
@@ -151,7 +151,7 @@ class TestPipelineManagerLoad(PipelineManagerTestBase):
             contents = f.read()
             assert 'from pyfileconf import Selector' in contents
             assert 'from typing import List' in contents
-            assert 'from tests.input_files.bmodule import ExampleClass' in contents
+            assert 'from tests.input_files.mypackage.cmodule import ExampleClass' in contents
             assert 's = Selector()' in contents
             assert 'a: ExampleClass = None' in contents
             assert 'b: List[str] = None' in contents
@@ -330,7 +330,7 @@ class TestPipelineManagerLoad(PipelineManagerTestBase):
         with open(class_paths[1], 'r') as f:
             contents = f.read()
             assert "from typing import Optional" in contents
-            assert "from tests.input_files.bmodule import ExampleClass" in contents
+            assert "from tests.input_files.mypackage.cmodule import ExampleClass" in contents
             assert "s = Selector()" in contents
             assert "b: ExampleClass = None" in contents
             assert "name: Optional[str] = 'data'" in contents


### PR DESCRIPTION
More flexibly skip modules which cause issues, currently just six.moves but was coming as multiple different import paths, now as long as path ends in a skip module then it will be skipped.